### PR TITLE
Se modifica la consulta al API de OrionX

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,8 +280,16 @@
 	})();
 
 	$(document).ready(function() {
-		$.get('https://api.orionx.io/graphql?query={marketOrderBook(marketCode:"CHACLP"){mid}}', function(data) {
-		$("#data").text(data['data']['marketOrderBook']['mid']);
+		$.ajax({
+			url: "https://api.orionx.io/graphql", 
+			method: "POST",
+			contentType: "application/json",
+			data: JSON.stringify({
+				query: "{marketOrderBook(marketCode:\"CHACLP\") {mid}}"
+			}),
+			success: function (data) {
+				$("#data").text(data['data']['marketOrderBook']['mid']);
+			}
 		});
 	});
 </script>


### PR DESCRIPTION
El API de OrionX actualmente solo soporta llamadas tipo POST, por lo que se modifica el tipo de consulta para que muestre correctamente el precio en la web.