### PR TITLE
Centrar sección que estaba alineada a la izquierda

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 	<!-- Intro section start -->
 		<section class="intro-section sp-pad spad">
 				<div class="container-fluid">
-					<div class="row">
+					<div class="row justify-content-center">
 						<div class="col-xl-4 intro-text">
 							<h3 class="sp-title">Chaucha</h3>
 							<p>La primera creación por parte del Proyecto Chaucha, fue diseñada para cumplir la función de ejemplo de criptomoneda 100% funcional, que sirve de guía para los futuros desarrollos de la organización.


### PR DESCRIPTION
Centrar sección que estaba alineada a la izquierda en resoluciones grandes (sobre 1140px)

Despues:
![image](https://user-images.githubusercontent.com/28690088/114753142-6957a800-9d57-11eb-85c4-bb2a5912c4b9.png)

Antes:
![image](https://user-images.githubusercontent.com/28690088/114753189-74123d00-9d57-11eb-84dd-3bba5f9cc2f0.png)
